### PR TITLE
Tanya/fix tests and keyid

### DIFF
--- a/odoh.go
+++ b/odoh.go
@@ -51,9 +51,7 @@ func (k ObliviousDNSPublicKey) KeyID() []byte {
 	h.Write(message)
 	keyIdHash := h.Sum(nil)
 
-	result := make([]byte, 2)
-	binary.BigEndian.PutUint16(result, uint16(len(keyIdHash)))
-	return append(result, keyIdHash...)
+	return keyIdHash
 }
 
 func (k ObliviousDNSPublicKey) Marshal() []byte {

--- a/odoh.go
+++ b/odoh.go
@@ -232,8 +232,9 @@ func (privateKey ObliviousDNSKeyPair) DecryptQuery(message ObliviousDNSMessage) 
 		return nil, err
 	}
 
-	enc := message.EncryptedMessage[0:32]
-	ct := message.EncryptedMessage[32:]
+	keySize := suite.KEM.PublicKeySize()
+	enc := message.EncryptedMessage[0:keySize]
+	ct := message.EncryptedMessage[keySize:]
 
 	ctxR, err := hpke.SetupBaseR(suite, privateKey.SecretKey, enc, []byte("odns-query"))
 	if err != nil {

--- a/odoh_test.go
+++ b/odoh_test.go
@@ -204,14 +204,9 @@ func Test_Sender_ODOHQueryEncryption(t *testing.T) {
 	}
 
 	encryptedMessage, err := targetKey.EncryptQuery(message)
-	fmt.Printf("%v\n", encryptedMessage)
-
 	if err != nil {
 		t.Fatalf("Failed to encrypt the message using the public key.")
 	}
-
-	encryptedMessageMarshal := encryptedMessage.Marshal()
-	fmt.Printf("%v\n", encryptedMessageMarshal)
 
 	dnsQuery, err := odohKeyPair.DecryptQuery(encryptedMessage)
 	if err != nil {
@@ -303,9 +298,6 @@ func TestOdohPublicKeyMarshalUnmarshal(t *testing.T) {
 	}
 
 	serializedPublicKey := targetKey.Marshal()
-
-	fmt.Printf("%v %v\n", len(serializedPublicKey), serializedPublicKey)
-
 	deserializedPublicKey := UnMarshalObliviousDNSPublicKey(serializedPublicKey)
 
 	if !bytes.Equal(deserializedPublicKey.PublicKeyBytes, targetKey.PublicKeyBytes) {

--- a/odoh_test.go
+++ b/odoh_test.go
@@ -214,7 +214,13 @@ func Test_Sender_ODOHQueryEncryption(t *testing.T) {
 	fmt.Printf("%v\n", encryptedMessageMarshal)
 
 	dnsQuery, err := odohKeyPair.DecryptQuery(encryptedMessage)
-	fmt.Printf("%v\n", dnsQuery)
+	if err != nil {
+		t.Fatalf("Failed to decrypt message with error: %s", err)
+	}
+
+	if !bytes.Equal(dnsQuery.DnsMessage, dnsMessage) {
+		t.Fatalf("Incorrect dnsMessage returned")
+	}
 }
 
 func TestResponseEncryption(t *testing.T) {

--- a/odoh_test.go
+++ b/odoh_test.go
@@ -134,7 +134,7 @@ func TestQueryEncryption(t *testing.T) {
 }
 
 func TestKeyID(t *testing.T) {
-	expectedKeyId := "002050106dbb316e7bf98bc862fd71e131d28cd871a11af84b19f323e465f32f1006"
+	expectedKeyId := "50106dbb316e7bf98bc862fd71e131d28cd871a11af84b19f323e465f32f1006"
 	expectedKeyIdBytes, err := hex.DecodeString(expectedKeyId)
 	if err != nil {
 		t.Fatal("Failed to decode AAD")


### PR DESCRIPTION
`DecryptQuery` did not consider KEM key size, which was causing a failing test, however, this test wasn't flagged because the return error of `DecryptQuery` was not being checked. 

`KeyID()` was redundantly adding the length of the key, when this length is supposed to be added during serialization. 

