### PR TITLE
Update implementation to match proposed spec changes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,17 @@
 [![Coverage Status](http://codecov.io/github/chris-wood/odoh/coverage.svg?branch=master)](http://codecov.io/github/chris-wood/odoh?branch=master)
 [![GoDoc](https://godoc.org/github.com/chris-wood/odoh?status.svg)](https://godoc.org/github.com/chris-wood/odoh)
 [![Go Report Card](https://goreportcard.com/badge/github.com/chris-wood/odoh)](https://goreportcard.com/report/github.com/chris-wood/odoh)
+
+## Test vector generation
+
+To generate test vectors, run:
+
+```
+$ ODOH_TEST_VECTORS_OUT=test-vectors.json go test -v -run TestVectorGenerate
+```
+
+To check test vectors, run:
+
+```
+$ ODOH_TEST_VECTORS_IN=test-vectors.json go test -v -run TestVectorVerify
+```

--- a/codec_test.go
+++ b/codec_test.go
@@ -5,27 +5,34 @@ import (
 	"testing"
 )
 
-func TestEncodeLengthPrefixedSlice(t *testing.T) {
-	test_array := []byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
-	result := encodeLengthPrefixedSlice(test_array)
-	expectation := []byte{0x00, 0x09, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+func TestEncodeEmptySlice(t *testing.T) {
+	expectedBytes := []byte{0x00, 0x00}
+	if !bytes.Equal(encodeLengthPrefixedSlice(nil), expectedBytes) {
+		t.Fatalf("Result mismatch.")
+	}
+}
 
-	if !bytes.Equal(result, expectation) {
+func TestEncodeLengthPrefixedSlice(t *testing.T) {
+	testData := []byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+	result := encodeLengthPrefixedSlice(testData)
+	expectedBytes := []byte{0x00, 0x09, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+
+	if !bytes.Equal(result, expectedBytes) {
 		t.Fatalf("Result mismatch.")
 	}
 }
 
 func TestDecodeLengthPrefixedSlice(t *testing.T) {
-	test_array := []byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
-	result := encodeLengthPrefixedSlice(test_array)
-	decoded_result, length, err := decodeLengthPrefixedSlice(result)
+	testData := []byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+	result := encodeLengthPrefixedSlice(testData)
+	decodedBytes, length, err := decodeLengthPrefixedSlice(result)
 	if err != nil {
 		t.Fatalf("Raised an error. Decoding error.")
 	}
-	if !bytes.Equal(test_array, decoded_result) {
+	if !bytes.Equal(testData, decodedBytes) {
 		t.Fatalf("Decoding result mismatch.")
 	}
-	if len(test_array)+2 != length {
+	if len(testData)+2 != length {
 		t.Fatalf("Incorrect length in the encoded message.")
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,7 @@ go 1.14
 
 require (
 	git.schwanenlied.me/yawning/x448.git v0.0.0-20170617130356-01b048fb03d6 // indirect
-	github.com/cisco/go-hpke v0.0.0-20200710171132-37d332d5f613
+	github.com/cisco/go-hpke v0.0.0-20200904203048-9e7d3e90b7c3
 	github.com/cisco/go-tls-syntax v0.0.0-20200617162716-46b0cfb76b9b // indirect
 	github.com/cloudflare/circl v1.0.0 // indirect
-	golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ git.schwanenlied.me/yawning/x448.git v0.0.0-20170617130356-01b048fb03d6 h1:w8IZg
 git.schwanenlied.me/yawning/x448.git v0.0.0-20170617130356-01b048fb03d6/go.mod h1:wQaGCqEu44ykB17jZHCevrgSVl3KJnwQBObUtrKU4uU=
 github.com/cisco/go-hpke v0.0.0-20200710171132-37d332d5f613 h1:u9M24d+jQHVN+NfFmEaprJgqPIgJCYvBenR1T216ep0=
 github.com/cisco/go-hpke v0.0.0-20200710171132-37d332d5f613/go.mod h1:7ykSQZaBVJLIRoJ7OMiJgpdOD74cTHdXRo6XPMIfu20=
+github.com/cisco/go-hpke v0.0.0-20200904203048-9e7d3e90b7c3 h1:3PT/MB4kSeuHr78O8Dkf538V7HrtdckYyi4STn8iJYM=
+github.com/cisco/go-hpke v0.0.0-20200904203048-9e7d3e90b7c3/go.mod h1:AyK7f6CWiLAvOFmAyCEF5xDN51zS6PIZgj3Qq7hla1Y=
 github.com/cisco/go-tls-syntax v0.0.0-20200617162716-46b0cfb76b9b h1:Ves2turKTX7zruivAcUOQg155xggcbv3suVdbKCBQNM=
 github.com/cisco/go-tls-syntax v0.0.0-20200617162716-46b0cfb76b9b/go.mod h1:0AZAV7lYvynZQ5ErHlGMKH+4QYMyNCFd+AiL9MlrCYA=
 github.com/cloudflare/circl v1.0.0 h1:64b6pyfCFbYm623ncIkYGNZaOcmIbyd+CjyMi2L9vdI=
@@ -16,6 +18,8 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9 h1:vEg9joUBmeBcK9iSJftGNf3coIG4HqZElCPehJsfAYM=
 golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a h1:vclmkQCjlDX5OydZ9wv8rBCcS0QyQY66Mpf/7BZbInM=
+golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/interop_test.go
+++ b/interop_test.go
@@ -21,7 +21,7 @@ func Test_Golang_Encryption_For_Rust_Decryption(t *testing.T) {
 		Go lang based client using the odoh library first uses the public key given by a rust target server
 		and encrypts the message. The goal of this test is to assert the following:
 
-		1. A valid serialized ObliviousDNSPublicKey from Rust can be converted into the corresponding object.
+		1. A valid serialized ObliviousDoHConfigContents from Rust can be converted into the corresponding object.
 		2. The encryption of a message can happen successfully.
 	*/
 
@@ -34,7 +34,7 @@ func Test_Golang_Encryption_For_Rust_Decryption(t *testing.T) {
 
 	fmt.Printf("%v\n", rustProvidedPublicKeyBytes)
 
-	odohPkFromRustBytes := UnMarshalObliviousDNSPublicKey(rustProvidedPublicKeyBytes)
+	odohPkFromRustBytes := UnmarshalObliviousDoHConfigContents(rustProvidedPublicKeyBytes)
 
 	fmt.Printf("ODOH PK : %v\n", odohPkFromRustBytes)
 }
@@ -62,7 +62,7 @@ func Test_Golang_ODOH_KeyPair_Generation_and_Serialize(t *testing.T) {
 		t.Fatalf("[%x, %x, %x] Error generating DH key pair: %s", kemID, kdfID, aeadID, err)
 	}
 
-	targetKey := ObliviousDNSPublicKey{
+	targetKey := ObliviousDoHConfigContents{
 		KemID:          kemID,
 		KdfID:          kdfID,
 		AeadID:         aeadID,

--- a/messages.go
+++ b/messages.go
@@ -23,11 +23,8 @@
 package odoh
 
 import (
-	"crypto/aes"
-	"crypto/cipher"
 	"encoding/binary"
 	"fmt"
-	"github.com/cisco/go-hpke"
 )
 
 type ObliviousMessageType uint8
@@ -37,80 +34,74 @@ const (
 	ResponseType ObliviousMessageType = 0x02
 )
 
-type ObliviousDNSQuery struct {
-	ResponseKey []byte
-	DnsMessage  []byte
+//
+// struct {
+//    opaque dns_message<1..2^16-1>;
+//    opaque padding<0..2^16-1>;
+// } ObliviousDoHQueryBody;
+//
+type ObliviousDNSMessageBody struct {
+	DnsMessage []byte
+	Padding    []byte
 }
 
-func (m ObliviousDNSQuery) Marshal() []byte {
-	result := encodeLengthPrefixedSlice(m.ResponseKey)
-	result = append(result, encodeLengthPrefixedSlice(m.DnsMessage)...)
-	return result
+func (m ObliviousDNSMessageBody) Marshal() []byte {
+	return append(encodeLengthPrefixedSlice(m.DnsMessage), encodeLengthPrefixedSlice(m.Padding)...)
 }
 
-func UnmarshalQueryBody(data []byte) (*ObliviousDNSQuery, error) {
-	keyLength := binary.BigEndian.Uint16(data)
-	if int(2+keyLength) > len(data) {
-		return nil, fmt.Errorf("Invalid key length")
+func UnmarshalMessageBody(data []byte) (ObliviousDNSMessageBody, error) {
+	messageLength := binary.BigEndian.Uint16(data)
+	if int(2+messageLength) > len(data) {
+		return ObliviousDNSMessageBody{}, fmt.Errorf("Invalid DNS message length")
 	}
-	key := data[2 : 2+keyLength]
+	message := data[2 : 2+messageLength]
 
-	messageLength := binary.BigEndian.Uint16(data[2+keyLength:])
-	if int(2+keyLength+2+messageLength) > len(data) {
-		return nil, fmt.Errorf("Invalid DNS message length")
+	paddingLength := binary.BigEndian.Uint16(data[2+messageLength:])
+	if int(2+messageLength+2+paddingLength) > len(data) {
+		return ObliviousDNSMessageBody{}, fmt.Errorf("Invalid DNS padding length")
 	}
 
-	message := data[2+keyLength+2 : 2+keyLength+2+messageLength]
-
-	return &ObliviousDNSQuery{
-		ResponseKey: key,
-		DnsMessage:  message,
+	padding := data[2+messageLength+2 : 2+messageLength+2+paddingLength]
+	return ObliviousDNSMessageBody{
+		DnsMessage: message,
+		Padding:    padding,
 	}, nil
 }
 
-func (m ObliviousDNSQuery) Message() []byte {
+func (m ObliviousDNSMessageBody) Message() []byte {
 	return m.DnsMessage
 }
 
-func (m ObliviousDNSQuery) EncryptResponse(suite hpke.CipherSuite, aad, response []byte) ([]byte, error) {
-	// TODO(caw): we need to support other ciphersuites, so dispatch on `suite`
-	block, err := aes.NewCipher(m.ResponseKey)
-	if err != nil {
-		return nil, err
-	}
-
-	nonce := make([]byte, suite.AEAD.NonceSize())
-	aesgcm, err := cipher.NewGCM(block)
-	if err != nil {
-		return nil, err
-	}
-
-	ciphertext := aesgcm.Seal(nil, nonce, response, aad)
-
-	return ciphertext, nil
+type ObliviousDNSQuery struct {
+	ObliviousDNSMessageBody
 }
 
-type ObliviousDNSResponse struct {
-	ResponseKey []byte
+func CreateObliviousDNSQuery(query []byte, paddingBytes int) *ObliviousDNSQuery {
+	msg := ObliviousDNSMessageBody{
+		DnsMessage: query,
+		Padding:    make([]byte, paddingBytes),
+	}
+	return &ObliviousDNSQuery{
+		msg,
+	}
 }
 
-func (r ObliviousDNSResponse) DecryptResponse(suite hpke.CipherSuite, aad, response []byte) ([]byte, error) {
-	// TODO(caw): we need to support other ciphersuites, so dispatch on `suite`
-	block, err := aes.NewCipher(r.ResponseKey)
+func UnmarshalQueryBody(data []byte) (*ObliviousDNSQuery, error) {
+	msg, err := UnmarshalMessageBody(data)
 	if err != nil {
 		return nil, err
 	}
 
-	nonce := make([]byte, suite.AEAD.NonceSize())
-	aesgcm, err := cipher.NewGCM(block)
-	if err != nil {
-		return nil, err
-	}
-
-	plaintext, err := aesgcm.Open(nil, nonce, response, aad)
-	return plaintext, err
+	return &ObliviousDNSQuery{msg}, nil
 }
 
+//
+// struct {
+//    opaque key_id<0..2^16-1>;
+//    uint8  message_type;
+//    opaque encrypted_message<1..2^16-1>;
+// } ObliviousDoHMessage;
+//
 type ObliviousDNSMessage struct {
 	MessageType      ObliviousMessageType
 	KeyID            []byte
@@ -139,22 +130,22 @@ func (m ObliviousDNSMessage) Marshal() []byte {
 	return result
 }
 
-func UnmarshalDNSMessage(data []byte) (*ObliviousDNSMessage, error) {
+func UnmarshalDNSMessage(data []byte) (ObliviousDNSMessage, error) {
 	if len(data) < 1 {
-		return nil, fmt.Errorf("Invalid data length: %d", len(data))
+		return ObliviousDNSMessage{}, fmt.Errorf("Invalid data length: %d", len(data))
 	}
 
 	messageType := data[0]
-	keyID, offset, err := decodeLengthPrefixedSlice(data[1:])
+	keyID, messageOffset, err := decodeLengthPrefixedSlice(data[1:])
 	if err != nil {
-		return nil, err
+		return ObliviousDNSMessage{}, err
 	}
-	encryptedMessage, offset, err := decodeLengthPrefixedSlice(data[1+offset:])
+	encryptedMessage, _, err := decodeLengthPrefixedSlice(data[1+messageOffset:])
 	if err != nil {
-		return nil, err
+		return ObliviousDNSMessage{}, err
 	}
 
-	return &ObliviousDNSMessage{
+	return ObliviousDNSMessage{
 		MessageType:      ObliviousMessageType(messageType),
 		KeyID:            keyID,
 		EncryptedMessage: encryptedMessage,

--- a/messages.go
+++ b/messages.go
@@ -97,8 +97,8 @@ func UnmarshalQueryBody(data []byte) (*ObliviousDNSQuery, error) {
 
 //
 // struct {
-//    opaque key_id<0..2^16-1>;
 //    uint8  message_type;
+//    opaque key_id<0..2^16-1>;
 //    opaque encrypted_message<1..2^16-1>;
 // } ObliviousDoHMessage;
 //

--- a/messages.go
+++ b/messages.go
@@ -95,6 +95,29 @@ func UnmarshalQueryBody(data []byte) (*ObliviousDNSQuery, error) {
 	return &ObliviousDNSQuery{msg}, nil
 }
 
+type ObliviousDNSResponse struct {
+	ObliviousDNSMessageBody
+}
+
+func CreateObliviousDNSResponse(response []byte, paddingBytes int) *ObliviousDNSResponse {
+	msg := ObliviousDNSMessageBody{
+		DnsMessage: response,
+		Padding:    make([]byte, paddingBytes),
+	}
+	return &ObliviousDNSResponse{
+		msg,
+	}
+}
+
+func UnmarshalResponseBody(data []byte) (*ObliviousDNSResponse, error) {
+	msg, err := UnmarshalMessageBody(data)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ObliviousDNSResponse{msg}, nil
+}
+
 //
 // struct {
 //    uint8  message_type;

--- a/messages_test.go
+++ b/messages_test.go
@@ -5,6 +5,25 @@ import (
 	"testing"
 )
 
+func TestObliviousMessageMarshalEmptyKeyId(t *testing.T) {
+	testMessage := []byte{0x06, 0x07, 0x08, 0x09}
+	message := ObliviousDNSMessage{
+		MessageType:      0xFF,
+		KeyID:            nil,
+		EncryptedMessage: testMessage,
+	}
+
+	marshaled_query := message.Marshal()
+	expected_bytes := []byte{
+		0xFF,
+		0x00, 0x00,
+		0x00, 0x04}
+	expected_bytes = append(expected_bytes, testMessage...)
+	if !bytes.Equal(marshaled_query, expected_bytes) {
+		t.Fatalf("Marshalling mismatch in the encoding. Got %x, received %x", marshaled_query, expected_bytes)
+	}
+}
+
 func TestObliviousDoHQueryNoPaddingMarshal(t *testing.T) {
 	dnsMessage := []byte{0x06, 0x07, 0x08, 0x09}
 	query := CreateObliviousDNSQuery(dnsMessage, 0)

--- a/messages_test.go
+++ b/messages_test.go
@@ -5,21 +5,39 @@ import (
 	"testing"
 )
 
-func TestObliviousDNSQuery_Marshal(t *testing.T) {
-	responseKey := []byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05}
+func TestObliviousDoHQueryNoPaddingMarshal(t *testing.T) {
 	dnsMessage := []byte{0x06, 0x07, 0x08, 0x09}
-	query := ObliviousDNSQuery{
-		ResponseKey: responseKey,
-		DnsMessage:  dnsMessage,
-	}
+	query := CreateObliviousDNSQuery(dnsMessage, 0)
+
 	marshaled_query := query.Marshal()
-	expected_bytes := []byte{0x00, 0x06, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x00, 0x04, 0x06, 0x07, 0x08, 0x09}
+	expected_bytes := []byte{
+		0x00, 0x04,
+		0x06, 0x07, 0x08, 0x09,
+		0x00, 0x00}
 	if !bytes.Equal(marshaled_query, expected_bytes) {
 		t.Fatalf("Marshalling mismatch in the encoding.")
 	}
 }
 
-func TestObliviousDNSMessage_Marshal(t *testing.T) {
+func TestObliviousDoHQueryPaddingMarshal(t *testing.T) {
+	dnsMessage := []byte{0x06, 0x07, 0x08, 0x09}
+
+	paddingLength := 8
+	paddedBytes := make([]byte, paddingLength)
+	query := CreateObliviousDNSQuery(dnsMessage, paddingLength)
+
+	marshaled_query := query.Marshal()
+	expected_bytes := []byte{
+		0x00, 0x04,
+		0x06, 0x07, 0x08, 0x09,
+		0x00, uint8(paddingLength)}
+	expected_bytes = append(expected_bytes, paddedBytes...)
+	if !bytes.Equal(marshaled_query, expected_bytes) {
+		t.Fatalf("Marshalling mismatch in the encoding.")
+	}
+}
+
+func TestObliviousDoHMessage_Marshal(t *testing.T) {
 	messageType := QueryType
 	keyId := []byte{0x00, 0x01, 0x02, 0x03, 0x04}
 	encryptedMessage := []byte{0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F}
@@ -38,11 +56,11 @@ func TestObliviousDNSMessage_Marshal(t *testing.T) {
 		0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F}
 
 	if !bytes.Equal(serialized_odns_message, expectation) {
-		t.Fatalf("Failed to serialize correctly.")
+		t.Fatalf("Failed to serialize correctly. Got %x, expected %x", serialized_odns_message, expectation)
 	}
 }
 
-func TestObliviousDNSMessage_Unmarshal(t *testing.T) {
+func TestObliviousDoHMessage_Unmarshal(t *testing.T) {
 	messageType := QueryType
 	keyId := []byte{0x00, 0x01, 0x02, 0x03, 0x04}
 	encryptedMessage := []byte{0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F}

--- a/odoh.go
+++ b/odoh.go
@@ -255,8 +255,7 @@ type QueryContext struct {
 }
 
 func (c QueryContext) DecryptResponse(message ObliviousDNSMessage) ([]byte, error) {
-	responseKeyId := []byte{0x00, 0x00} // 0-length encoded KeyID
-	aad := append([]byte{byte(ResponseType)}, responseKeyId...)
+	aad := append([]byte{byte(ResponseType)}, []byte{0x00, 0x00}...) // 0-length encoded KeyID
 
 	odohPRK := c.suite.KDF.Extract(c.query, c.odohSecret)
 	key := c.suite.KDF.Expand(odohPRK, []byte(ODOH_LABEL_KEY), c.suite.AEAD.KeySize())
@@ -277,8 +276,7 @@ type ResponseContext struct {
 }
 
 func (c ResponseContext) EncryptResponse(response []byte) (ObliviousDNSMessage, error) {
-	responseKeyId := []byte{0x00, 0x00} // 0-length encoded KeyID
-	aad := append([]byte{byte(ResponseType)}, responseKeyId...)
+	aad := append([]byte{byte(ResponseType)}, []byte{0x00, 0x00}...) // 0-length encoded KeyID
 
 	odohPRK := c.suite.KDF.Extract(c.query, c.odohSecret)
 	key := c.suite.KDF.Expand(odohPRK, []byte(ODOH_LABEL_KEY), c.suite.AEAD.KeySize())
@@ -292,7 +290,7 @@ func (c ResponseContext) EncryptResponse(response []byte) (ObliviousDNSMessage, 
 	ciphertext := aead.Seal(nil, nonce, response, aad)
 
 	odohMessage := ObliviousDNSMessage{
-		KeyID:            responseKeyId,
+		KeyID:            nil,
 		MessageType:      ResponseType,
 		EncryptedMessage: ciphertext,
 	}

--- a/odoh.go
+++ b/odoh.go
@@ -24,37 +24,81 @@ package odoh
 
 import (
 	"crypto/rand"
-	"crypto/sha256"
+	"crypto/subtle"
 	"encoding/binary"
 	"errors"
 	"github.com/cisco/go-hpke"
 	"log"
 )
 
-type ObliviousDNSPublicKey struct {
+const (
+	ODOH_VERSION       = uint16(0x0001)
+	ODOH_SECRET_LENGTH = 32
+	ODOH_PADDING_BYTE  = uint8(0)
+	ODOH_LABEL_KEY    = "odoh key"
+	ODOH_LABEL_NONCE  = "odoh nonce"
+	ODOH_LABEL_SECRET = "odoh secret"
+	ODOH_LABEL_QUERY  = "odoh query"
+)
+
+type ObliviousDoHConfigContents struct {
 	KemID          hpke.KEMID
 	KdfID          hpke.KDFID
 	AeadID         hpke.AEADID
 	PublicKeyBytes []byte
 }
 
-func (k ObliviousDNSPublicKey) KeyID() []byte {
-	h := sha256.New()
+type ObliviousDoHConfig struct {
+	Version  uint16
+	Contents ObliviousDoHConfigContents
+}
+
+func (c ObliviousDoHConfig) Marshal() []byte {
+	marshalledConfig := c.Contents.Marshal()
+
+	buffer := make([]byte, 4)
+	binary.BigEndian.PutUint16(buffer[0:], uint16(c.Version))
+	binary.BigEndian.PutUint16(buffer[2:], uint16(len(marshalledConfig)))
+
+	configBytes := append(buffer, marshalledConfig...)
+	return configBytes
+}
+
+func UnmarshalObliviousDoHConfig(buffer []byte) (ObliviousDoHConfig, error) {
+	version := binary.BigEndian.Uint16(buffer[0:])
+	length := binary.BigEndian.Uint16(buffer[2:])
+	if len(buffer[4:]) < int(length) {
+		return ObliviousDoHConfig{}, errors.New("Invalid serialized ObliviousDoHConfig")
+	}
+
+	configContents := UnmarshalObliviousDoHConfigContents(buffer[4:])
+
+	return ObliviousDoHConfig{
+		Version:  version,
+		Contents: configContents,
+	}, nil
+}
+
+func (k ObliviousDoHConfigContents) KeyID() []byte {
+	suite, err := hpke.AssembleCipherSuite(k.KemID, k.KdfID, k.AeadID)
+	if err != nil {
+		return nil
+	}
 
 	identifiers := make([]byte, 8)
 	binary.BigEndian.PutUint16(identifiers[0:], uint16(k.KemID))
 	binary.BigEndian.PutUint16(identifiers[2:], uint16(k.KdfID))
 	binary.BigEndian.PutUint16(identifiers[4:], uint16(k.AeadID))
 	binary.BigEndian.PutUint16(identifiers[6:], uint16(len(k.PublicKeyBytes)))
-	message := append(identifiers, k.PublicKeyBytes...)
+	config := append(identifiers, k.PublicKeyBytes...)
 
-	h.Write(message)
-	keyIdHash := h.Sum(nil)
+	prk := suite.KDF.Extract(nil, config)
+	identifier := suite.KDF.Expand(prk, []byte("odoh_key_id"), suite.KDF.OutputSize())
 
-	return keyIdHash
+	return identifier
 }
 
-func (k ObliviousDNSPublicKey) Marshal() []byte {
+func (k ObliviousDoHConfigContents) Marshal() []byte {
 	identifiers := make([]byte, 8)
 	binary.BigEndian.PutUint16(identifiers[0:], uint16(k.KemID))
 	binary.BigEndian.PutUint16(identifiers[2:], uint16(k.KdfID))
@@ -65,7 +109,7 @@ func (k ObliviousDNSPublicKey) Marshal() []byte {
 	return response
 }
 
-func UnMarshalObliviousDNSPublicKey(buffer []byte) ObliviousDNSPublicKey {
+func UnmarshalObliviousDoHConfigContents(buffer []byte) ObliviousDoHConfigContents {
 	kemId := binary.BigEndian.Uint16(buffer[0:])
 	kdfId := binary.BigEndian.Uint16(buffer[2:])
 	AeadId := binary.BigEndian.Uint16(buffer[4:])
@@ -128,7 +172,7 @@ func UnMarshalObliviousDNSPublicKey(buffer []byte) ObliviousDNSPublicKey {
 		log.Fatalln("Unable to find correct AEAD ID Type")
 	}
 
-	return ObliviousDNSPublicKey{
+	return ObliviousDoHConfigContents{
 		KemID:          KemID,
 		KdfID:          KdfID,
 		AeadID:         AeadID,
@@ -136,21 +180,22 @@ func UnMarshalObliviousDNSPublicKey(buffer []byte) ObliviousDNSPublicKey {
 	}
 }
 
-func (k ObliviousDNSPublicKey) GetPublicKeyBytes() []byte {
+func (k ObliviousDoHConfigContents) PublicKey() []byte {
 	return k.PublicKeyBytes
 }
 
-func (k ObliviousDNSPublicKey) CipherSuite() (hpke.CipherSuite, error) {
+func (k ObliviousDoHConfigContents) CipherSuite() (hpke.CipherSuite, error) {
 	return hpke.AssembleCipherSuite(k.KemID, k.KdfID, k.AeadID)
 }
 
 type ObliviousDNSKeyPair struct {
-	PublicKey ObliviousDNSPublicKey
+	Config    ObliviousDoHConfig
 	SecretKey hpke.KEMPrivateKey
+	Seed      []byte
 }
 
 func (k ObliviousDNSKeyPair) CipherSuite() (hpke.CipherSuite, error) {
-	return hpke.AssembleCipherSuite(k.PublicKey.KemID, k.PublicKey.KdfID, k.PublicKey.AeadID)
+	return hpke.AssembleCipherSuite(k.Config.Contents.KemID, k.Config.Contents.KdfID, k.Config.Contents.AeadID)
 }
 
 func DeriveFixedKeyPairFromSeed(kemID hpke.KEMID, kdfID hpke.KDFID, aeadID hpke.AEADID, ikm []byte) (ObliviousDNSKeyPair, error) {
@@ -164,14 +209,16 @@ func DeriveFixedKeyPairFromSeed(kemID hpke.KEMID, kdfID hpke.KDFID, aeadID hpke.
 		return ObliviousDNSKeyPair{}, err
 	}
 
-	publicKey := ObliviousDNSPublicKey{
-		KemID:          kemID,
-		KdfID:          kdfID,
-		AeadID:         aeadID,
-		PublicKeyBytes: suite.KEM.Serialize(pk),
+	config := ObliviousDoHConfig{
+		Contents: ObliviousDoHConfigContents{
+			KemID:          kemID,
+			KdfID:          kdfID,
+			AeadID:         aeadID,
+			PublicKeyBytes: suite.KEM.Serialize(pk),
+		},
 	}
 
-	return ObliviousDNSKeyPair{publicKey, sk}, nil
+	return ObliviousDNSKeyPair{config, sk, ikm}, nil
 }
 
 func CreateKeyPair(kemID hpke.KEMID, kdfID hpke.KDFID, aeadID hpke.AEADID) (ObliviousDNSKeyPair, error) {
@@ -187,140 +234,171 @@ func CreateKeyPair(kemID hpke.KEMID, kdfID hpke.KDFID, aeadID hpke.AEADID) (Obli
 		return ObliviousDNSKeyPair{}, err
 	}
 
-	publicKey := ObliviousDNSPublicKey{
-		KemID:          kemID,
-		KdfID:          kdfID,
-		AeadID:         aeadID,
-		PublicKeyBytes: suite.KEM.Serialize(pk),
+	config := ObliviousDoHConfig{
+		Contents: ObliviousDoHConfigContents{
+			KemID:          kemID,
+			KdfID:          kdfID,
+			AeadID:         aeadID,
+			PublicKeyBytes: suite.KEM.Serialize(pk),
+		},
 	}
 
-	return ObliviousDNSKeyPair{publicKey, sk}, nil
+	return ObliviousDNSKeyPair{config, sk, ikm}, nil
 }
 
-func (targetKey ObliviousDNSPublicKey) EncryptQuery(query ObliviousDNSQuery) (ObliviousDNSMessage, error) {
-	suite, err := hpke.AssembleCipherSuite(targetKey.KemID, targetKey.KdfID, targetKey.AeadID)
+type QueryContext struct {
+	odohSecret []byte
+	suite      hpke.CipherSuite
+	query      []byte
+	publicKey  ObliviousDoHConfigContents
+}
+
+func (c QueryContext) DecryptResponse(message ObliviousDNSMessage) ([]byte, error) {
+	responseKeyId := []byte{0x00, 0x00}
+	aad := append([]byte{0x02}, responseKeyId...) // TODO(caw): use actual enum value
+
+	odohPRK := c.suite.KDF.Extract(c.query, c.odohSecret)
+	key := c.suite.KDF.Expand(odohPRK, []byte(ODOH_LABEL_KEY), c.suite.AEAD.KeySize())
+	nonce := c.suite.KDF.Expand(odohPRK, []byte(ODOH_LABEL_NONCE), c.suite.AEAD.NonceSize())
+
+	aead, err := c.suite.AEAD.New(key)
+	if err != nil {
+		return nil, err
+	}
+
+	return aead.Open(nil, nonce, message.EncryptedMessage, aad)
+}
+
+type ResponseContext struct {
+	query      []byte
+	suite      hpke.CipherSuite
+	odohSecret []byte
+}
+
+func (c ResponseContext) EncryptResponse(response []byte) (ObliviousDNSMessage, error) {
+	responseKeyId := []byte{0x00, 0x00}
+	aad := append([]byte{0x02}, responseKeyId...) // TODO(caw): use actual enum value
+
+	odohPRK := c.suite.KDF.Extract(c.query, c.odohSecret)
+	key := c.suite.KDF.Expand(odohPRK, []byte(ODOH_LABEL_KEY), c.suite.AEAD.KeySize())
+	nonce := c.suite.KDF.Expand(odohPRK, []byte(ODOH_LABEL_NONCE), c.suite.AEAD.NonceSize())
+
+	aead, err := c.suite.AEAD.New(key)
 	if err != nil {
 		return ObliviousDNSMessage{}, err
+	}
+
+	ciphertext := aead.Seal(nil, nonce, response, aad)
+
+	odohMessage := ObliviousDNSMessage{
+		KeyID:            responseKeyId,
+		MessageType:      ResponseType,
+		EncryptedMessage: ciphertext,
+	}
+
+	return odohMessage, nil
+}
+
+func (targetKey ObliviousDoHConfigContents) EncryptQuery(query *ObliviousDNSQuery) (ObliviousDNSMessage, QueryContext, error) {
+	suite, err := hpke.AssembleCipherSuite(targetKey.KemID, targetKey.KdfID, targetKey.AeadID)
+	if err != nil {
+		return ObliviousDNSMessage{}, QueryContext{}, err
 	}
 
 	pkR, err := suite.KEM.Deserialize(targetKey.PublicKeyBytes)
 	if err != nil {
-		return ObliviousDNSMessage{}, err
+		return ObliviousDNSMessage{}, QueryContext{}, err
 	}
 
-	enc, ctxI, err := hpke.SetupBaseS(suite, rand.Reader, pkR, []byte("odns-query"))
+	enc, ctxI, err := hpke.SetupBaseS(suite, rand.Reader, pkR, []byte(ODOH_LABEL_QUERY))
 	if err != nil {
-		return ObliviousDNSMessage{}, err
+		return ObliviousDNSMessage{}, QueryContext{}, err
 	}
 
 	encodedMessage := query.Marshal()
 	aad := append([]byte{0x01}, targetKey.KeyID()...)
 	ct := ctxI.Seal(aad, encodedMessage)
+	odohSecret := ctxI.Export([]byte(ODOH_LABEL_SECRET), ODOH_SECRET_LENGTH)
 
 	return ObliviousDNSMessage{
-		MessageType:      QueryType,
-		KeyID:            targetKey.KeyID(),
-		EncryptedMessage: append(enc, ct...),
-	}, nil
+			KeyID:            targetKey.KeyID(),
+			MessageType:      QueryType,
+			EncryptedMessage: append(enc, ct...),
+		}, QueryContext{
+			odohSecret: odohSecret,
+			suite:      suite,
+			query:      query.Marshal(),
+			publicKey:  targetKey,
+		}, nil
 }
 
-func (privateKey ObliviousDNSKeyPair) DecryptQuery(message ObliviousDNSMessage) (*ObliviousDNSQuery, error) {
-	suite, err := hpke.AssembleCipherSuite(privateKey.PublicKey.KemID, privateKey.PublicKey.KdfID, privateKey.PublicKey.AeadID)
+func validateMessagePadding(padding []byte) bool {
+	validPadding := 1
+	for _, v := range padding {
+		validPadding &= subtle.ConstantTimeByteEq(v, ODOH_PADDING_BYTE)
+	}
+	return validPadding == 1
+}
+
+func (privateKey ObliviousDNSKeyPair) DecryptQuery(message ObliviousDNSMessage) (*ObliviousDNSQuery, ResponseContext, error) {
+	suite, err := hpke.AssembleCipherSuite(privateKey.Config.Contents.KemID, privateKey.Config.Contents.KdfID, privateKey.Config.Contents.AeadID)
 	if err != nil {
-		return nil, err
+		return nil, ResponseContext{}, err
 	}
 
 	keySize := suite.KEM.PublicKeySize()
 	enc := message.EncryptedMessage[0:keySize]
 	ct := message.EncryptedMessage[keySize:]
 
-	ctxR, err := hpke.SetupBaseR(suite, privateKey.SecretKey, enc, []byte("odns-query"))
+	ctxR, err := hpke.SetupBaseR(suite, privateKey.SecretKey, enc, []byte(ODOH_LABEL_QUERY))
 	if err != nil {
-		log.Printf("Bailed here. %v", err)
-		return nil, err
+		return nil, ResponseContext{}, err
 	}
 
-	aad := append([]byte{byte(QueryType)}, privateKey.PublicKey.KeyID()...)
+	odohSecret := ctxR.Export([]byte(ODOH_LABEL_SECRET), ODOH_SECRET_LENGTH)
+
+	aad := append([]byte{byte(QueryType)}, privateKey.Config.Contents.KeyID()...)
 
 	dnsMessage, err := ctxR.Open(aad, ct)
 	if err != nil {
-		return nil, err
+		return nil, ResponseContext{}, err
 	}
 
-	return UnmarshalQueryBody(dnsMessage)
-}
-
-type QueryContext struct {
-	key       []byte
-	publicKey ObliviousDNSPublicKey
-}
-
-func lookupAeadKeySizeByAeadID(id hpke.AEADID) int {
-	switch id {
-	case hpke.AEAD_AESGCM128:
-		return 16
-	case hpke.AEAD_AESGCM256:
-		return 32
-	case hpke.AEAD_CHACHA20POLY1305:
-		return 32
-	default:
-		return 0
-	}
-}
-
-func createQueryContext(publicKey ObliviousDNSPublicKey) QueryContext {
-	keySize := lookupAeadKeySizeByAeadID(publicKey.AeadID)
-	if keySize == 0 {
-		return QueryContext{
-			key:       nil,
-			publicKey: publicKey,
-		}
-	}
-	responseKey := make([]byte, keySize)
-	_, err := rand.Read(responseKey)
+	query, err := UnmarshalQueryBody(dnsMessage)
 	if err != nil {
-		return QueryContext{
-			key:       nil,
-			publicKey: publicKey,
-		}
+		return nil, ResponseContext{}, err
 	}
-	return QueryContext{
-		key:       responseKey,
-		publicKey: publicKey,
+
+	if !validateMessagePadding(query.Padding) {
+		return nil, ResponseContext{}, errors.New("invalid padding")
 	}
+
+	responseContext := ResponseContext{
+		odohSecret: odohSecret,
+		suite:      suite,
+		query:      query.Marshal(),
+	}
+
+	return query, responseContext, nil
 }
 
-func SealQuery(dnsQuery []byte, publicKey ObliviousDNSPublicKey) ([]byte, QueryContext, error) {
-	queryContext := createQueryContext(publicKey)
-	odohQuery := ObliviousDNSQuery{
-		ResponseKey: queryContext.key,
-		DnsMessage:  dnsQuery,
-	}
+func SealQuery(dnsQuery []byte, publicKey ObliviousDoHConfigContents) (ObliviousDNSMessage, QueryContext, error) {
+	odohQuery := CreateObliviousDNSQuery(dnsQuery, 0)
 
-	odnsMessage, err := queryContext.publicKey.EncryptQuery(odohQuery)
+	odohMessage, queryContext, err := publicKey.EncryptQuery(odohQuery)
 	if err != nil {
-		log.Fatalf("Unable to Encrypt oDoH Question with provided Public Key of Resolver")
-		return nil, queryContext, err
+		return ObliviousDNSMessage{}, QueryContext{}, err
 	}
 
-	return odnsMessage.Marshal(), queryContext, nil
+	return odohMessage, queryContext, nil
 }
 
-func (c QueryContext) OpenAnswer(encryptedDnsAnswer []byte) ([]byte, error) {
-	message := CreateObliviousDNSMessage(ResponseType, []byte{}, encryptedDnsAnswer)
-	odohResponse := ObliviousDNSResponse{ResponseKey: c.key}
-	responseMessageType := message.MessageType
-	if responseMessageType != ResponseType {
+func (c QueryContext) OpenAnswer(odohResponse ObliviousDNSMessage) ([]byte, error) {
+	if odohResponse.MessageType != ResponseType {
 		return nil, errors.New("answer is not a valid response type")
 	}
-	encryptedResponse := message.EncryptedMessage
 
-	responseKeyId := []byte{0x00, 0x00}
-	aad := append([]byte{0x02}, responseKeyId...) // message_type = 0x02, with an empty keyID
-
-	suite, err := hpke.AssembleCipherSuite(c.publicKey.KemID, c.publicKey.KdfID, c.publicKey.AeadID)
-
-	decryptedResponse, err := odohResponse.DecryptResponse(suite, aad, encryptedResponse)
+	decryptedResponse, err := c.DecryptResponse(odohResponse)
 	if err != nil {
 		return nil, errors.New("unable to decrypt the obtained response using the symmetric key sent")
 	}

--- a/odoh_test.go
+++ b/odoh_test.go
@@ -293,7 +293,8 @@ func TestSealQueryAndOpenAnswer(t *testing.T) {
 
 	_, responseContext, err := kp.DecryptQuery(encryptedData)
 
-	encryptedAnswer, err := responseContext.EncryptResponse(mockAnswerData)
+	mockResponse := CreateObliviousDNSResponse(mockAnswerData, 0)
+	encryptedAnswer, err := responseContext.EncryptResponse(mockResponse)
 
 	response, err := queryContext.OpenAnswer(encryptedAnswer)
 
@@ -487,7 +488,9 @@ func generateTransaction(t *testing.T, kp ObliviousDNSKeyPair, querySize int) tr
 	// Run the query/response transaction
 	obliviousQuery, queryContext, err := SealQuery(mockQuery, kp.Config.Contents)
 	_, responseContext, err := kp.DecryptQuery(obliviousQuery)
-	obliviousResponse, err := responseContext.EncryptResponse(mockAnswer)
+
+	mockResponse := CreateObliviousDNSResponse(mockAnswer, 0)
+	obliviousResponse, err := responseContext.EncryptResponse(mockResponse)
 	response, err := queryContext.OpenAnswer(obliviousResponse)
 
 	if err != nil || !bytes.Equal(response, mockAnswer) {
@@ -542,7 +545,8 @@ func verifyTestVector(t *testing.T, tv testVector) {
 		assertNotError(t, "Query decryption failed", err)
 		assertBytesEqual(t, "Query decryption mismatch", query.DnsMessage, transaction.query)
 
-		obliviousResponse, err := responseContext.EncryptResponse(transaction.response)
+		testResponse := CreateObliviousDNSResponse(transaction.response, 0)
+		obliviousResponse, err := responseContext.EncryptResponse(testResponse)
 		assertNotError(t, "Response encryption failed", err)
 		assertBytesEqual(t, "Response encryption mismatch", obliviousResponse.Marshal(), transaction.obliviousResponse.Marshal())
 
@@ -554,7 +558,7 @@ func verifyTestVector(t *testing.T, tv testVector) {
 		}
 		response, err := queryContext.OpenAnswer(obliviousResponse)
 		assertNotError(t, "Response decryption failed", err)
-		assertBytesEqual(t, "Response encryption mismatch", response, transaction.response)
+		assertBytesEqual(t, "Final response encryption mismatch", response, transaction.response)
 	}
 }
 

--- a/odoh_test.go
+++ b/odoh_test.go
@@ -398,6 +398,9 @@ func (etv *transactionTestVector) UnmarshalJSON(data []byte) error {
 }
 
 type rawTestVector struct {
+	KemID         int    `json:"kem_id"`
+	KdfID         int    `json:"kdf_id"`
+	AeadID        int    `json:"aead_id"`
 	Config        string `json:"odohconfig"`
 	PublicKeySeed string `json:"public_key_seed"`
 	KeyId         string `json:"key_id"`
@@ -407,6 +410,9 @@ type rawTestVector struct {
 
 type testVector struct {
 	t               *testing.T
+	kem_id          hpke.KEMID
+	kdf_id          hpke.KDFID
+	aead_id         hpke.AEADID
 	odoh_config     []byte
 	public_key_seed []byte
 	key_id          []byte
@@ -416,6 +422,9 @@ type testVector struct {
 
 func (tv testVector) MarshalJSON() ([]byte, error) {
 	return json.Marshal(rawTestVector{
+		KemID:         int(tv.kem_id),
+		KdfID:         int(tv.kdf_id),
+		AeadID:        int(tv.aead_id),
 		Config:        mustHex(tv.odoh_config),
 		PublicKeySeed: mustHex(tv.public_key_seed),
 		KeyId:         mustHex(tv.key_id),
@@ -430,6 +439,9 @@ func (tv *testVector) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	tv.kem_id = hpke.KEMID(raw.KemID)
+	tv.kdf_id = hpke.KDFID(raw.KdfID)
+	tv.aead_id = hpke.AEADID(raw.AeadID)
 	tv.public_key_seed = mustUnhex(tv.t, raw.PublicKeySeed)
 	tv.odoh_config = mustUnhex(tv.t, raw.Config)
 	tv.key_id = mustUnhex(tv.t, raw.KeyId)
@@ -503,6 +515,9 @@ func generateTestVector(t *testing.T, kem_id hpke.KEMID, kdf_id hpke.KDFID, aead
 
 	vector := testVector{
 		t:               t,
+		kem_id:          kem_id,
+		kdf_id:          kdf_id,
+		aead_id:         aead_id,
 		odoh_config:     kp.Config.Marshal(),
 		public_key_seed: kp.Seed,
 		key_id:          kp.Config.Contents.KeyID(),

--- a/odoh_test.go
+++ b/odoh_test.go
@@ -26,28 +26,29 @@ import (
 	"bytes"
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"github.com/cisco/go-hpke"
 	"io"
+	"io/ioutil"
+	"os"
 	"testing"
 )
 
+const (
+	outputTestVectorEnvironmentKey = "ODOH_TEST_VECTORS_OUT"
+	inputTestVectorEnvironmentKey  = "ODOH_TEST_VECTORS_IN"
+)
+
 func TestQueryBodyMarshal(t *testing.T) {
-	key := []byte{0x00, 0x01, 0x02, 0x04}
 	message := []byte{0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F}
 
-	queryBody := ObliviousDNSQuery{
-		ResponseKey: key,
-		DnsMessage:  message,
-	}
+	queryBody := CreateObliviousDNSQuery(message, 0)
 
 	encoded := queryBody.Marshal()
 	decoded, err := UnmarshalQueryBody(encoded)
 	if err != nil {
 		t.Fatalf("Encode/decode failed")
-	}
-	if !bytes.Equal(decoded.ResponseKey, key) {
-		t.Fatalf("Key mismatch")
 	}
 	if !bytes.Equal(decoded.DnsMessage, message) {
 		t.Fatalf("Key mismatch")
@@ -97,68 +98,35 @@ func TestQueryEncryption(t *testing.T) {
 		t.Fatalf("[%x, %x, %x] Error generating DH key pair: %s", kemID, kdfID, aeadID, err)
 	}
 
-	targetKey := ObliviousDNSPublicKey{
+	targetKey := ObliviousDoHConfigContents{
 		KemID:          kemID,
 		KdfID:          kdfID,
 		AeadID:         aeadID,
 		PublicKeyBytes: suite.KEM.Serialize(pkR),
 	}
 
-	odohKeyPair := ObliviousDNSKeyPair{targetKey, skR}
-	symmetricKey := make([]byte, suite.AEAD.KeySize())
-	rand.Read(symmetricKey)
+	targetConfig := ObliviousDoHConfig{
+		Contents: targetKey,
+	}
+
+	odohKeyPair := ObliviousDNSKeyPair{targetConfig, skR, ikm}
 
 	dnsMessage := []byte{0x01, 0x02}
 
-	message := ObliviousDNSQuery{
-		ResponseKey: symmetricKey,
-		DnsMessage:  dnsMessage,
-	}
+	message := CreateObliviousDNSQuery(dnsMessage, 0)
 
-	encryptedMessage, err := targetKey.EncryptQuery(message)
+	encryptedMessage, _, err := targetKey.EncryptQuery(message)
 	if err != nil {
 		t.Fatalf("EncryptQuery failed: %s", err)
 	}
 
-	result, err := odohKeyPair.DecryptQuery(encryptedMessage)
+	result, _, err := odohKeyPair.DecryptQuery(encryptedMessage)
 	if err != nil {
 		t.Fatalf("DecryptQuery failed: %s", err)
 	}
 
-	if !bytes.Equal(result.ResponseKey, symmetricKey) {
-		t.Fatalf("Incorrect key returned")
-	}
 	if !bytes.Equal(result.DnsMessage, dnsMessage) {
 		t.Fatalf("Incorrect DnsMessage returned")
-	}
-}
-
-func TestKeyID(t *testing.T) {
-	expectedKeyId := "50106dbb316e7bf98bc862fd71e131d28cd871a11af84b19f323e465f32f1006"
-	expectedKeyIdBytes, err := hex.DecodeString(expectedKeyId)
-	if err != nil {
-		t.Fatal("Failed to decode AAD")
-	}
-
-	publicKey := "85023a65b2c505cd2e92e2c427ef69df8aa8d0f18081a8090b159aafa6001413"
-	publicKeyBytes, err := hex.DecodeString(publicKey)
-	if err != nil {
-		t.Fatal("Failed to decode public key")
-	}
-
-	kemID := hpke.DHKEM_X25519
-	kdfID := hpke.KDF_HKDF_SHA256
-	aeadID := hpke.AEAD_AESGCM128
-	odohKey := ObliviousDNSPublicKey{
-		KemID:          kemID,
-		KdfID:          kdfID,
-		AeadID:         aeadID,
-		PublicKeyBytes: publicKeyBytes,
-	}
-
-	keyId := odohKey.KeyID()
-	if !bytes.Equal(keyId, expectedKeyIdBytes) {
-		t.Fatalf("Incorrect keyId returned")
 	}
 }
 
@@ -185,78 +153,36 @@ func Test_Sender_ODOHQueryEncryption(t *testing.T) {
 		t.Fatalf("[%x, %x, %x] Error generating DH key pair: %s", kemID, kdfID, aeadID, err)
 	}
 
-	targetKey := ObliviousDNSPublicKey{
+	targetKey := ObliviousDoHConfigContents{
 		KemID:          kemID,
 		KdfID:          kdfID,
 		AeadID:         aeadID,
 		PublicKeyBytes: suite.KEM.Serialize(pkR),
 	}
 
-	odohKeyPair := ObliviousDNSKeyPair{targetKey, skR}
+	targetConfig := ObliviousDoHConfig{
+		Contents: targetKey,
+	}
+
+	odohKeyPair := ObliviousDNSKeyPair{targetConfig, skR, ikm}
 	symmetricKey := make([]byte, suite.AEAD.KeySize())
 	rand.Read(symmetricKey)
 
 	dnsMessage := []byte{0x01, 0x02, 0x03}
+	message := CreateObliviousDNSQuery(dnsMessage, 0)
 
-	message := ObliviousDNSQuery{
-		ResponseKey: symmetricKey,
-		DnsMessage:  dnsMessage,
-	}
-
-	encryptedMessage, err := targetKey.EncryptQuery(message)
+	encryptedMessage, _, err := targetKey.EncryptQuery(message)
 	if err != nil {
 		t.Fatalf("Failed to encrypt the message using the public key.")
 	}
 
-	dnsQuery, err := odohKeyPair.DecryptQuery(encryptedMessage)
+	dnsQuery, _, err := odohKeyPair.DecryptQuery(encryptedMessage)
 	if err != nil {
 		t.Fatalf("Failed to decrypt message with error: %s", err)
 	}
 
 	if !bytes.Equal(dnsQuery.DnsMessage, dnsMessage) {
 		t.Fatalf("Incorrect dnsMessage returned")
-	}
-}
-
-func TestResponseEncryption(t *testing.T) {
-	kemID := hpke.DHKEM_X25519
-	kdfID := hpke.KDF_HKDF_SHA256
-	aeadID := hpke.AEAD_AESGCM128
-
-	suite, err := hpke.AssembleCipherSuite(kemID, kdfID, aeadID)
-	if err != nil {
-		t.Fatalf("[%x, %x, %x] Error looking up ciphersuite: %s", kemID, kdfID, aeadID, err)
-	}
-
-	responseKey := make([]byte, suite.AEAD.KeySize())
-	if _, err := io.ReadFull(rand.Reader, responseKey); err != nil {
-		t.Fatalf("Failed generating random key: %s", err)
-	}
-
-	aad := []byte("ODOH")
-	responseData := []byte("fake response")
-
-	query := ObliviousDNSQuery{
-		ResponseKey: responseKey,
-		DnsMessage:  nil,
-	}
-
-	encryptedResponse, err := query.EncryptResponse(suite, aad, responseData)
-	if err != nil {
-		t.Fatalf("Failed EncryptResponse: %s", err)
-	}
-
-	response := ObliviousDNSResponse{
-		ResponseKey: responseKey,
-	}
-
-	decryptedResponse, err := response.DecryptResponse(suite, aad, encryptedResponse)
-	if err != nil {
-		t.Fatalf("Failed EncryptResponse: %s", err)
-	}
-
-	if !bytes.Equal(decryptedResponse, responseData) {
-		t.Fatalf("Incorrect message returned")
 	}
 }
 
@@ -290,7 +216,7 @@ func TestOdohPublicKeyMarshalUnmarshal(t *testing.T) {
 		t.Fatalf("[%x, %x, %x] Error generating DH key pair: %s", kemID, kdfID, aeadID, err)
 	}
 
-	targetKey := ObliviousDNSPublicKey{
+	targetKey := ObliviousDoHConfigContents{
 		KemID:          kemID,
 		KdfID:          kdfID,
 		AeadID:         aeadID,
@@ -298,7 +224,7 @@ func TestOdohPublicKeyMarshalUnmarshal(t *testing.T) {
 	}
 
 	serializedPublicKey := targetKey.Marshal()
-	deserializedPublicKey := UnMarshalObliviousDNSPublicKey(serializedPublicKey)
+	deserializedPublicKey := UnmarshalObliviousDoHConfigContents(serializedPublicKey)
 
 	if !bytes.Equal(deserializedPublicKey.PublicKeyBytes, targetKey.PublicKeyBytes) {
 		t.Fatalf("The deserialized and serialized bytes do not match.")
@@ -323,22 +249,23 @@ func TestFixedOdohKeyPairCreation(t *testing.T) {
 		kdfID  = hpke.KDF_HKDF_SHA256
 		aeadID = hpke.AEAD_AESGCM128
 	)
+
 	// Fixed 16 byte seed
 	seedHex := "f7c664a7959b2aa02ffa7abb0d2022ab"
 	seed, err := hex.DecodeString(seedHex)
 	if err != nil {
-		fmt.Printf("Unable to decode seed to bytes")
+		t.Fatalf("Unable to decode seed to bytes")
 	}
 	keyPair, err := DeriveFixedKeyPairFromSeed(kemID, kdfID, aeadID, seed)
 	if err != nil {
-		fmt.Printf("Unable to derive a ObliviousDNSKeyPair")
+		t.Fatalf("Unable to derive a ObliviousDNSKeyPair")
 	}
 	for i := 0; i < 10; i++ {
 		keyPairDerived, err := DeriveFixedKeyPairFromSeed(kemID, kdfID, aeadID, seed)
 		if err != nil {
 			t.Fatalf("Unable to derive a ObliviousDNSKeyPair")
 		}
-		if !bytes.Equal(keyPairDerived.PublicKey.Marshal(), keyPair.PublicKey.Marshal()) {
+		if !bytes.Equal(keyPairDerived.Config.Contents.Marshal(), keyPair.Config.Contents.Marshal()) {
 			t.Fatalf("Public Key Derived does not match")
 		}
 	}
@@ -348,7 +275,6 @@ func TestSealQueryAndOpenAnswer(t *testing.T) {
 	kemID := hpke.DHKEM_X25519
 	kdfID := hpke.KDF_HKDF_SHA256
 	aeadID := hpke.AEAD_AESGCM128
-	suite, err := hpke.AssembleCipherSuite(kemID, kdfID, aeadID)
 
 	kp, err := CreateKeyPair(kemID, kdfID, aeadID)
 	if err != nil {
@@ -358,21 +284,327 @@ func TestSealQueryAndOpenAnswer(t *testing.T) {
 	dnsQueryData := make([]byte, 40)
 	_, err = rand.Read(dnsQueryData)
 
-	encryptedData, queryContext, err := SealQuery(dnsQueryData, kp.PublicKey)
+	encryptedData, queryContext, err := SealQuery(dnsQueryData, kp.Config.Contents)
 
 	mockAnswerData := make([]byte, 100)
 	_, err = rand.Read(mockAnswerData)
 
-	receivedEncryptedQuery, err := UnmarshalDNSMessage(encryptedData)
+	_, responseContext, err := kp.DecryptQuery(encryptedData)
 
-	queryRequested, err := kp.DecryptQuery(*receivedEncryptedQuery)
-	responseKeyId := []byte{0x00, 0x00}
-	aad := append([]byte{byte(ResponseType)}, responseKeyId...) // message_type = 0x02, with an empty keyID
-	encryptedAnswer, err := queryRequested.EncryptResponse(suite, aad, mockAnswerData)
+	encryptedAnswer, err := responseContext.EncryptResponse(mockAnswerData)
 
 	response, err := queryContext.OpenAnswer(encryptedAnswer)
 
 	if !bytes.Equal(response, mockAnswerData) {
-		t.Fatalf("Decryption of the result doesnot match encrypted value")
+		t.Fatalf("Decryption of the result does not match encrypted value")
 	}
+}
+
+///////
+// Assertions
+func assert(t *testing.T, msg string, test bool) {
+	if !test {
+		t.Fatalf("%s", msg)
+	}
+}
+
+func assertBytesEqual(t *testing.T, msg string, lhs, rhs []byte) {
+	realMsg := fmt.Sprintf("%s: [%x] != [%x]", msg, lhs, rhs)
+	assert(t, realMsg, bytes.Equal(lhs, rhs))
+}
+
+func assertNotError(t *testing.T, msg string, err error) {
+	realMsg := fmt.Sprintf("%s: %v", msg, err)
+	assert(t, realMsg, err == nil)
+}
+
+func fatalOnError(t *testing.T, err error, msg string) {
+	realMsg := fmt.Sprintf("%s: %v", msg, err)
+	if err != nil {
+		if t != nil {
+			t.Fatalf(realMsg)
+		} else {
+			panic(realMsg)
+		}
+	}
+}
+
+func mustUnhex(t *testing.T, h string) []byte {
+	out, err := hex.DecodeString(h)
+	fatalOnError(t, err, "Unhex failed")
+	return out
+}
+
+func mustHex(d []byte) string {
+	return hex.EncodeToString(d)
+}
+
+func mustDeserializePub(t *testing.T, suite hpke.CipherSuite, h string, required bool) hpke.KEMPublicKey {
+	pkm := mustUnhex(t, h)
+	pk, err := suite.KEM.Deserialize(pkm)
+	if required {
+		fatalOnError(t, err, "Deserialize failed")
+	}
+	return pk
+}
+
+func mustSerializePub(suite hpke.CipherSuite, pub hpke.KEMPublicKey) string {
+	return mustHex(suite.KEM.Serialize(pub))
+}
+
+///////
+// Query/Response transaction test vector structure
+type transactionTestVector struct {
+	query             []byte
+	response          []byte
+	obliviousQuery    ObliviousDNSMessage
+	obliviousResponse ObliviousDNSMessage
+}
+
+func (etv transactionTestVector) MarshalJSON() ([]byte, error) {
+	return json.Marshal(map[string]string{
+		"query":             mustHex(etv.query),
+		"response":          mustHex(etv.response),
+		"obliviousQuery":    mustHex(etv.obliviousQuery.Marshal()),
+		"obliviousResponse": mustHex(etv.obliviousResponse.Marshal()),
+	})
+}
+
+func (etv *transactionTestVector) UnmarshalJSON(data []byte) error {
+	raw := map[string]string{}
+	err := json.Unmarshal(data, &raw)
+	if err != nil {
+		return err
+	}
+
+	etv.query = mustUnhex(nil, raw["query"])
+	etv.response = mustUnhex(nil, raw["response"])
+
+	obliviousQueryBytes := mustUnhex(nil, raw["obliviousQuery"])
+	obliviousResponseBytes := mustUnhex(nil, raw["obliviousResponse"])
+
+	etv.obliviousQuery, err = UnmarshalDNSMessage(obliviousQueryBytes)
+	if err != nil {
+		return err
+	}
+	etv.obliviousResponse, err = UnmarshalDNSMessage(obliviousResponseBytes)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type rawTestVector struct {
+	Config        string `json:"odohconfig"`
+	PublicKeySeed string `json:"public_key_seed"`
+	KeyId         string `json:"key_id"`
+
+	Transactions []transactionTestVector `json:"transactions"`
+}
+
+type testVector struct {
+	t               *testing.T
+	odoh_config     []byte
+	public_key_seed []byte
+	key_id          []byte
+
+	transactions []transactionTestVector
+}
+
+func (tv testVector) MarshalJSON() ([]byte, error) {
+	return json.Marshal(rawTestVector{
+		Config:        mustHex(tv.odoh_config),
+		PublicKeySeed: mustHex(tv.public_key_seed),
+		KeyId:         mustHex(tv.key_id),
+		Transactions:  tv.transactions,
+	})
+}
+
+func (tv *testVector) UnmarshalJSON(data []byte) error {
+	raw := rawTestVector{}
+	err := json.Unmarshal(data, &raw)
+	if err != nil {
+		return err
+	}
+
+	tv.public_key_seed = mustUnhex(tv.t, raw.PublicKeySeed)
+	tv.odoh_config = mustUnhex(tv.t, raw.Config)
+	tv.key_id = mustUnhex(tv.t, raw.KeyId)
+
+	tv.transactions = raw.Transactions
+	return nil
+}
+
+type testVectorArray struct {
+	t       *testing.T
+	vectors []testVector
+}
+
+func (tva testVectorArray) MarshalJSON() ([]byte, error) {
+	return json.Marshal(tva.vectors)
+}
+
+func (tva *testVectorArray) UnmarshalJSON(data []byte) error {
+	err := json.Unmarshal(data, &tva.vectors)
+	if err != nil {
+		return err
+	}
+
+	for i := range tva.vectors {
+		tva.vectors[i].t = tva.t
+	}
+	return nil
+}
+
+func generateRandomData(n int) []byte {
+	data := make([]byte, n)
+	_, err := rand.Read(data)
+	if err != nil {
+		panic(err)
+	}
+	return data
+}
+
+func generateTransaction(t *testing.T, kp ObliviousDNSKeyPair) transactionTestVector {
+	mockQuery := generateRandomData(40)
+	mockAnswer := append(mockQuery, mockQuery...) // answer = query || query
+
+	// Run the query/response transaction
+	obliviousQuery, queryContext, err := SealQuery(mockQuery, kp.Config.Contents)
+	_, responseContext, err := kp.DecryptQuery(obliviousQuery)
+	obliviousResponse, err := responseContext.EncryptResponse(mockAnswer)
+	response, err := queryContext.OpenAnswer(obliviousResponse)
+
+	if err != nil || !bytes.Equal(response, mockAnswer) {
+		t.Fatalf("Decryption of the result does not match encrypted value")
+	}
+
+	return transactionTestVector{
+		query:             mockQuery,
+		obliviousQuery:    obliviousQuery,
+		response:          mockAnswer,
+		obliviousResponse: obliviousResponse,
+	}
+}
+
+func generateTestVector(t *testing.T, kem_id hpke.KEMID, kdf_id hpke.KDFID, aead_id hpke.AEADID) testVector {
+	kp, err := CreateKeyPair(kem_id, kdf_id, aead_id)
+	if err != nil {
+		t.Fatalf("Unable to create a Key Pair")
+	}
+
+	transaction := generateTransaction(t, kp)
+
+	vector := testVector{
+		t:               t,
+		odoh_config:     kp.Config.Marshal(),
+		public_key_seed: kp.Seed,
+		key_id:          kp.Config.Contents.KeyID(),
+		transactions:    []transactionTestVector{transaction},
+	}
+
+	return vector
+}
+
+func verifyTestVector(t *testing.T, tv testVector) {
+	config, err := UnmarshalObliviousDoHConfig(tv.odoh_config)
+	assertNotError(t, "UnmarshalObliviousDoHConfigContents failed", err)
+
+	kp, err := DeriveFixedKeyPairFromSeed(config.Contents.KemID, config.Contents.KdfID, config.Contents.AeadID, tv.public_key_seed)
+	assertNotError(t, "DeriveFixedKeyPairFromSeed failed", err)
+
+	expectedKeyId := kp.Config.Contents.KeyID()
+	assertBytesEqual(t, "KeyID mismatch", expectedKeyId, tv.key_id)
+
+	for _, transaction := range tv.transactions {
+		query, responseContext, err := kp.DecryptQuery(transaction.obliviousQuery)
+		assertNotError(t, "Query decryption failed", err)
+		assertBytesEqual(t, "Query decryption mismatch", query.DnsMessage, transaction.query)
+
+		obliviousResponse, err := responseContext.EncryptResponse(transaction.response)
+		assertNotError(t, "Response encryption failed", err)
+		assertBytesEqual(t, "Response encryption mismatch", obliviousResponse.Marshal(), transaction.obliviousResponse.Marshal())
+
+		// Extract decryption context, since we don't control the client's ephemeral key
+		queryContext := QueryContext{
+			odohSecret: responseContext.odohSecret,
+			query:      query.Marshal(),
+			suite:      responseContext.suite,
+		}
+		response, err := queryContext.OpenAnswer(obliviousResponse)
+		assertNotError(t, "Response decryption failed", err)
+		assertBytesEqual(t, "Response encryption mismatch", response, transaction.response)
+	}
+}
+
+func vectorTest(vector testVector) func(t *testing.T) {
+	return func(t *testing.T) {
+		verifyTestVector(t, vector)
+	}
+}
+
+func verifyTestVectors(t *testing.T, vectorString []byte, subtest bool) {
+	vectors := testVectorArray{t: t}
+	err := json.Unmarshal(vectorString, &vectors)
+	if err != nil {
+		t.Fatalf("Error decoding test vector string: %v", err)
+	}
+
+	for _, tv := range vectors.vectors {
+		test := vectorTest(tv)
+		if !subtest {
+			test(t)
+		} else {
+			label := fmt.Sprintf("config=%x", tv.odoh_config)
+			t.Run(label, test)
+		}
+	}
+}
+
+func TestVectorGenerate(t *testing.T) {
+	supportedKEMs := []hpke.KEMID{hpke.DHKEM_X25519}
+	supportedKDFs := []hpke.KDFID{hpke.KDF_HKDF_SHA256}
+	supportedAEADs := []hpke.AEADID{hpke.AEAD_AESGCM128}
+
+	vectors := make([]testVector, 0)
+	for _, kem_id := range supportedKEMs {
+		for _, kdf_id := range supportedKDFs {
+			for _, aead_id := range supportedAEADs {
+				vectors = append(vectors, generateTestVector(t, kem_id, kdf_id, aead_id))
+			}
+		}
+	}
+
+	// Encode the test vectors
+	encoded, err := json.Marshal(vectors)
+	if err != nil {
+		t.Fatalf("Error producing test vectors: %v", err)
+	}
+
+	// Verify that we process them correctly
+	verifyTestVectors(t, encoded, false)
+
+	// Write them to a file if requested
+	var outputFile string
+	if outputFile = os.Getenv(outputTestVectorEnvironmentKey); len(outputFile) > 0 {
+		err = ioutil.WriteFile(outputFile, encoded, 0644)
+		if err != nil {
+			t.Fatalf("Error writing test vectors: %v", err)
+		}
+	}
+}
+
+func TestVectorVerify(t *testing.T) {
+	var inputFile string
+	if inputFile = os.Getenv(inputTestVectorEnvironmentKey); len(inputFile) == 0 {
+		t.Skip("Test vectors were not provided")
+	}
+
+	encoded, err := ioutil.ReadFile(inputFile)
+	if err != nil {
+		t.Fatalf("Failed reading test vectors: %v", err)
+	}
+
+	verifyTestVectors(t, encoded, true)
 }


### PR DESCRIPTION
This also adds test vector generation machinery. The test vectors encode the information needed to reconstruct the target's private key, and then one or more query/response transactions. Each transaction has plaintext (expected) query and response, as well as the corresponding oblivious query and response in wire format, serialized as a hex string. Because the HPKE library doesn't let us fix the ephemeral key for encryption, I don't see an easy way to also fix that. (So, there's room for improvement, but it's a start!)

cc @picowar, @sudheesh001, @tfpauly 

~~~
[
    {
        "aead_id": 1,
        "kdf_id": 1,
        "kem_id": 32,
        "key_id": "c3673430c43f35cdb427bd659e6c71a83c387242a1615d7aa00fa9b2cca0467a",
        "odohconfig": "00000028002000010001002040d105c6793eff8964e869ec1d55f7a3c78962c1c39a2158ee5e8f675443be34",
        "public_key_seed": "5a2f57d6a133eec88ce3490899f321998adc53a7e8edbb9e68af3771c5f70360",
        "transactions": [
            {
                "obliviousQuery": "010020c3673430c43f35cdb427bd659e6c71a83c387242a1615d7aa00fa9b2cca0467a00544ffdf033647967e544300a2705576208b44324a66dc1241fe40adcf26c0cb26130fda66995f76e48376f02b9058c21856eec0c9a527d805b0ed711a021b6b59dba2fc8bb4c0ceafb843ba82863507423ec4c7122",
                "obliviousResponse": "02000000545bde6d9b21744d689a55d0b46e54d12bfecf91858ca8c6590a8cbe71e23ac6e61dd3bbbba47cd0cb87400a8400f055496fb715c90cd2a87c90d59865a38ce9cc6853099531fc000df6bf431c4e824aa7a637d9da",
                "query": "d75af210b45cbfd67c7da79a3bab9823be07a68a2e2aa09c4813db34331bc02c",
                "response": "d75af210b45cbfd67c7da79a3bab9823be07a68a2e2aa09c4813db34331bc02cd75af210b45cbfd67c7da79a3bab9823be07a68a2e2aa09c4813db34331bc02c"
            },
            {
                "obliviousQuery": "010020c3673430c43f35cdb427bd659e6c71a83c387242a1615d7aa00fa9b2cca0467a0074987336d4347010af1d43f174e716e199279307933c0fbfbd26e460668fc7120df64bf8a9b6691ddb22ae4677cb7034069a691b6a4ea6b0938c88995ca0fafec017cbf7ebd4f49f1d297475be9e0d9243a13009cd2baa0867b1f32aabe1d1de5f2e1625f00a12afbb59ac9edf989c5b301ce4b4f0",
                "obliviousResponse": "0200000094ad6248481eafae0aef9450ae9c4b1cc6289c1656380aa29640747bf16115d810d71d5f60b7b30696f4fba3fd2127e70f1b93fdff02c1f8859e13c9451b655ff0f4409aa91de88e816a24b98668311d93e6877661d9cc618f3ae2b72dcd5bcbc8da82fa3c429fe30e31a01d9669bf7cb0ba95d16b986befdbd221acdf57a22b04e70d3827d702a0af1e44636fdd56a5bea6cc3304",
                "query": "0a99a1fd17e5dd24afcac1e6d16079e5d71eb34134208194c1e24af6e8a4897c07e82583075b385d0a5c7d261d53741c2e1c9db2943a042a654087a21de41d86",
                "response": "0a99a1fd17e5dd24afcac1e6d16079e5d71eb34134208194c1e24af6e8a4897c07e82583075b385d0a5c7d261d53741c2e1c9db2943a042a654087a21de41d860a99a1fd17e5dd24afcac1e6d16079e5d71eb34134208194c1e24af6e8a4897c07e82583075b385d0a5c7d261d53741c2e1c9db2943a042a654087a21de41d86"
            }
        ]
    }
]

~~~